### PR TITLE
convert to use an event handler

### DIFF
--- a/batchthresholdbundling.civix.php
+++ b/batchthresholdbundling.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Batchthresholdbundling_ExtensionUtil {
-  const SHORT_NAME = "batchthresholdbundling";
-  const LONG_NAME = "biz.jmaconsulting.batchthresholdbundling";
-  const CLASS_PREFIX = "CRM_Batchthresholdbundling";
+  const SHORT_NAME = 'batchthresholdbundling';
+  const LONG_NAME = 'biz.jmaconsulting.batchthresholdbundling';
+  const CLASS_PREFIX = 'CRM_Batchthresholdbundling';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Batchthresholdbundling_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -82,7 +82,7 @@ use CRM_Batchthresholdbundling_ExtensionUtil as E;
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _batchthresholdbundling_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -100,7 +100,7 @@ function _batchthresholdbundling_civix_civicrm_config(&$config = NULL) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
@@ -112,7 +112,7 @@ function _batchthresholdbundling_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _batchthresholdbundling_civix_civicrm_xmlMenu(&$files) {
   foreach (_batchthresholdbundling_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -123,7 +123,7 @@ function _batchthresholdbundling_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _batchthresholdbundling_civix_civicrm_install() {
   _batchthresholdbundling_civix_civicrm_config();
@@ -135,12 +135,12 @@ function _batchthresholdbundling_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _batchthresholdbundling_civix_civicrm_postInstall() {
   _batchthresholdbundling_civix_civicrm_config();
   if ($upgrader = _batchthresholdbundling_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -149,7 +149,7 @@ function _batchthresholdbundling_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _batchthresholdbundling_civix_civicrm_uninstall() {
   _batchthresholdbundling_civix_civicrm_config();
@@ -161,12 +161,12 @@ function _batchthresholdbundling_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _batchthresholdbundling_civix_civicrm_enable() {
   _batchthresholdbundling_civix_civicrm_config();
   if ($upgrader = _batchthresholdbundling_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
@@ -175,13 +175,13 @@ function _batchthresholdbundling_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _batchthresholdbundling_civix_civicrm_disable() {
   _batchthresholdbundling_civix_civicrm_config();
   if ($upgrader = _batchthresholdbundling_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,10 +193,11 @@ function _batchthresholdbundling_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _batchthresholdbundling_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _batchthresholdbundling_civix_upgrader()) {
@@ -217,22 +218,23 @@ function _batchthresholdbundling_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _batchthresholdbundling_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
     return CRM_Utils_File::findFiles($dir, $pattern);
   }
 
-  $todos = array($dir);
-  $result = array();
+  $todos = [$dir];
+  $result = [];
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_batchthresholdbundling_civix_glob("$subdir/$pattern") as $match) {
@@ -243,7 +245,7 @@ function _batchthresholdbundling_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;
@@ -254,15 +256,17 @@ function _batchthresholdbundling_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _batchthresholdbundling_civix_civicrm_managed(&$entities) {
   $mgdFiles = _batchthresholdbundling_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
@@ -284,7 +288,7 @@ function _batchthresholdbundling_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _batchthresholdbundling_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -295,14 +299,13 @@ function _batchthresholdbundling_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
+    $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -313,7 +316,7 @@ function _batchthresholdbundling_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _batchthresholdbundling_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -332,6 +335,25 @@ function _batchthresholdbundling_civix_civicrm_angularModules(&$angularModules) 
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _batchthresholdbundling_civix_civicrm_themes(&$themes) {
+  $files = _batchthresholdbundling_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
  * Glob wrapper which is guaranteed to return an array.
  *
  * The documentation for glob() says, "On some systems it is impossible to
@@ -341,11 +363,12 @@ function _batchthresholdbundling_civix_civicrm_angularModules(&$angularModules) 
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _batchthresholdbundling_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
@@ -356,16 +379,18 @@ function _batchthresholdbundling_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _batchthresholdbundling_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -376,9 +401,9 @@ function _batchthresholdbundling_civix_insert_navigation_menu(&$menu, $path, $it
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _batchthresholdbundling_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _batchthresholdbundling_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -389,7 +414,7 @@ function _batchthresholdbundling_civix_insert_navigation_menu(&$menu, $path, $it
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _batchthresholdbundling_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _batchthresholdbundling_civix_fixNavigationMenu($nodes);
   }
 }
@@ -431,17 +456,11 @@ function _batchthresholdbundling_civix_fixNavigationMenuItems(&$nodes, &$maxNavI
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _batchthresholdbundling_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }
@@ -451,10 +470,8 @@ function _batchthresholdbundling_civix_civicrm_alterSettingsFolders(&$metaDataFo
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _batchthresholdbundling_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/batchthresholdbundling.php
+++ b/batchthresholdbundling.php
@@ -90,7 +90,7 @@ function bundleTrxns($event) {
           if (in_array($account, $bankingFeesIds)) {
             $bankAccount = $entries[$id]['account_name'];
             $unsetBankingFeeIds[$bankAccount][] = $id;
-            $totalBankingFeeAmounts[$bankAccount] = empty($totalBankingFeeAmounts[$account]) ? $entries[$id]['AMOUNT'] : ($totalBankingFeeAmounts[$account] + $entries[$id]['AMOUNT']);
+            $totalBankingFeeAmounts[$bankAccount] = empty($totalBankingFeeAmounts[$bankAccount]) ? $entries[$id]['AMOUNT'] : ($totalBankingFeeAmounts[$bankAccount] + $entries[$id]['AMOUNT']);
           }
           else {
             // All non-banking fee entries are bundled by financial account ID.

--- a/batchthresholdbundling.php
+++ b/batchthresholdbundling.php
@@ -108,8 +108,11 @@ function bundleTrxns($event) {
         foreach ($unsetBankingFeeIds[$bankAccount] as $id) {
           unset($financialItems['ENTRIES'][$id]);
         }
-        $description = "Bundled banking fee transactions: $bankAccount";
-        $financialItems['ENTRIES'][] = array_merge($finalEntry, ['DESCRIPTION' => $description]);
+        // If the amounts wash to zero, we don't need to include it at all.  E.g. when all payments on a financial account are reversed.
+        if ($finalEntry['AMOUNT']) {
+          $description = "Bundled banking fee transactions: $bankAccount";
+          $financialItems['ENTRIES'][] = array_merge($finalEntry, ['DESCRIPTION' => $description]);
+        }
       }
       // Bundle the transactions (by financial account ID) and remove the bundled entries.
       foreach ($totalAmounts as $account => $amountTotal) {
@@ -119,8 +122,11 @@ function bundleTrxns($event) {
           $accountName = $financialItems['ENTRIES'][$id]['account_name'];
           unset($financialItems['ENTRIES'][$id]);
         }
-        $description = "Bundled transactions: $accountName";
-        $financialItems['ENTRIES'][] = array_merge($finalEntry, ['DESCRIPTION' => $description]);
+        // If the amounts wash to zero, we don't need to include it at all.  E.g. when all payments on a financial account are reversed.
+        if ($finalEntry['AMOUNT']) {
+          $description = "Bundled transactions: $accountName";
+          $financialItems['ENTRIES'][] = array_merge($finalEntry, ['DESCRIPTION' => $description]);
+        }
       }
     }
     $event->items = $financialItems;


### PR DESCRIPTION
I have a need to run a separate extension using the same hook, so I converted this hook to be called through the Symfony EventDispatcher.  This allows us to specify the order in which hooks run. [amongst other advantages](https://docs.civicrm.org/dev/en/latest/hooks/usage/symfony/).